### PR TITLE
Fix python3.8 incompatibilities

### DIFF
--- a/blazeform/element.py
+++ b/blazeform/element.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
+import html
 import inspect
 from os import path
-import cgi
 
 import formencode
 import formencode.validators as fev
@@ -126,7 +126,7 @@ class ElementBase(HtmlAttributeHolder):
 
     def add_note(self, note, escape=True):
         if escape:
-            note = cgi.escape(note)
+            note = html.escape(note)
         self.notes.append(note)
 
 

--- a/blazeform/util.py
+++ b/blazeform/util.py
@@ -199,12 +199,12 @@ class ElementRegistrar(object):
 
 class HtmlAttributeHolder(object):
     def __init__(self, **kwargs):
-        self._cleankeys(kwargs)
+        kwargs = self._cleankeys(kwargs)
         #: a dictionary that represents html attributes
         self.attributes = kwargs
 
     def set_attrs(self, **kwargs):
-        self._cleankeys(kwargs)
+        kwargs = self._cleankeys(kwargs)
         self.attributes.update(kwargs)
 
     def set_attr(self, key, value):
@@ -249,7 +249,4 @@ class HtmlAttributeHolder(object):
             in with an underscore at the end (i.e. "class_").  We want to
             remove the underscore before saving
         """
-        for key, val in dict.items():
-            if key.endswith('_'):
-                del dict[key]
-                dict[key[:-1]] = val
+        return {key[:-1] if key.endswith('_') else key: val for key, val in dict.items()}


### PR DESCRIPTION
- Don't mutate dict keys in loop
- Replace cgi.escape with html.escape (could break backwards-compatibility, but that may not be a concern)

Refs blazelibs/blazeform#3